### PR TITLE
Fixing blog post link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mais detalhes podem ser vistos neste post.
 
 [Missão/Visão/Valores](Missao.md)
 
-[Culture Code](https://blog.coderockr.com/culture-code-da-coderockr-17f1789e7731)
+[Culture Code](https://blog.coderockr.com/posts/2017/culture-code-da-coderockr/)
 
 [Summary](Summary.md)
 


### PR DESCRIPTION
I guess this is a correct link: `https://blog.coderockr.com/posts/2017/culture-code-da-coderockr/` for Culture Code item